### PR TITLE
Refactor Bible Quest to Static WebView Build + Fix Splash Flicker

### DIFF
--- a/BibleQuestForKids/App.xaml.cs
+++ b/BibleQuestForKids/App.xaml.cs
@@ -1,5 +1,8 @@
+using System.Threading.Tasks;
 using Microsoft.Maui;
+using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
 
 namespace BibleQuestForKids;
 
@@ -8,6 +11,31 @@ public partial class App : Application
     public App()
     {
         InitializeComponent();
-        MainPage = new MainPage();
+
+        // Show a branded splash handoff before the WebView is ready. Keeps TestFlight/App Store builds consistent.
+        MainPage = new ContentPage
+        {
+            BackgroundColor = Colors.White,
+            Content = new Grid
+            {
+                Children =
+                {
+                    new Image
+                    {
+                        Source = "Resources/Images/splash.png",
+                        Aspect = Aspect.AspectFit,
+                        HorizontalOptions = LayoutOptions.Center,
+                        VerticalOptions = LayoutOptions.Center
+                    }
+                }
+            }
+        };
+
+        // Warm up the WebView after the splash appears, then swap the actual page in place.
+        MainThread.BeginInvokeOnMainThread(async () =>
+        {
+            await Task.Delay(500);
+            MainPage = new MainPage();
+        });
     }
 }

--- a/BibleQuestForKids/BibleQuestForKids.csproj
+++ b/BibleQuestForKids/BibleQuestForKids.csproj
@@ -42,13 +42,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="8.0.*" />
+    <!-- Pure WebView build: no Blazor runtime package required. -->
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Keep the built React + Blazor assets bundled with the MAUI app -->
-    <MauiAsset Include="wwwroot/dist/**/*"
-               LogicalName="wwwroot/dist/%(RecursiveDir)%(Filename)%(Extension)" />
+    <!-- Ship only the compiled Vite assets. Keep logical paths aligned for MAUI bundle. -->
+    <MauiAsset Include="wwwroot/dist/**"
+               LogicalName="wwwroot/%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/BibleQuestForKids/MainPage.xaml
+++ b/BibleQuestForKids/MainPage.xaml
@@ -1,14 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:blazor="clr-namespace:Microsoft.AspNetCore.Components.WebView.Maui;assembly=Microsoft.AspNetCore.Components.WebView.Maui"
-             xmlns:components="clr-namespace:BibleQuestForKids.Components"
-             x:Class="BibleQuestForKids.MainPage">
-
-    <blazor:BlazorWebView HostPage="wwwroot/dist/index.html">
-        <blazor:BlazorWebView.RootComponents>
-            <blazor:RootComponent Selector="#app"
-                                  ComponentType="{x:Type components:ReactHost}" />
-        </blazor:BlazorWebView.RootComponents>
-    </blazor:BlazorWebView>
+             x:Class="BibleQuestForKids.MainPage"
+             NavigationPage.HasNavigationBar="False">
+    <Grid>
+        <WebView x:Name="AppWebView" />
+    </Grid>
 </ContentPage>

--- a/BibleQuestForKids/MainPage.xaml.cs
+++ b/BibleQuestForKids/MainPage.xaml.cs
@@ -1,4 +1,5 @@
 using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
 
 namespace BibleQuestForKids;
 
@@ -7,5 +8,10 @@ public partial class MainPage : ContentPage
     public MainPage()
     {
         InitializeComponent();
+        // Transparent background avoids a white flash during WebView initialization.
+        AppWebView.BackgroundColor = Colors.Transparent;
+
+        // Load the bundled Vite build directly from the application package.
+        AppWebView.Source = "appbundle:/wwwroot/dist/index.html";
     }
 }

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -57,22 +57,19 @@ workflows:
           export PATH="$DOTNET_ROOT:$PATH"
           "$DOTNET_ROOT/dotnet" --info
 
-      - name: Install MAUI & WASM workloads
+      - name: Install MAUI workload
         script: |
           set -euo pipefail
           export PATH="$DOTNET_ROOT:$PATH"
           mkdir -p "$HOME/.dotnet/temp"
-          # MAUI for iOS + Blazor hybrid uses the MAUI tooling and the WebAssembly toolchain.
+          # Only the MAUI iOS workload is required for the static WebView build.
           "$DOTNET_ROOT/dotnet" workload install maui-ios --skip-manifest-update --temp-dir "$HOME/.dotnet/temp"
-          "$DOTNET_ROOT/dotnet" workload install wasm-tools --skip-manifest-update --temp-dir "$HOME/.dotnet/temp"
           "$DOTNET_ROOT/dotnet" workload restore BibleQuestForKids/BibleQuestForKids.csproj
 
       - name: Restore NuGet packages
         script: |
           set -euo pipefail
           export PATH="$DOTNET_ROOT:$PATH"
-          # Restoring here guarantees the Microsoft.AspNetCore.Components.WebView.Maui pack exists
-          # before we merge the WebAssembly runtime into the hybrid bundle.
           "$DOTNET_ROOT/dotnet" restore BibleQuestForKids/BibleQuestForKids.csproj
 
       - name: Validate iOS icon catalog
@@ -83,7 +80,7 @@ workflows:
           python3 "$ICONSET/materialize_icons.py"
           python3 "$ICONSET/validate_icons.py"
 
-      - name: Build bundled web assets (npm + Blazor runtime)
+      - name: Build bundled web assets (Vite)
         script: |
           set -euo pipefail
           export PATH="$DOTNET_ROOT:$PATH"
@@ -92,109 +89,20 @@ workflows:
           npm ci
           npm run build
           cd ../..
-
-          # Publish headless Blazor runtime project
-          dotnet publish ci/blazor-runtime/BlazorRuntimeStub.csproj \
-            -c Release -o blazor-wasm-out
-
-          if [ ! -f blazor-wasm-out/wwwroot/_framework/blazor.boot.json ]; then
-            echo "ERROR: blazor.boot.json missing in Blazor runtime output"
-            exit 1
-          fi
-
-          mkdir -p BibleQuestForKids/wwwroot/dist/_framework
-          cp -r blazor-wasm-out/wwwroot/_framework/* BibleQuestForKids/wwwroot/dist/_framework/
-
-          echo "✅ Blazor runtime merged into dist/_framework"
-          ls -l BibleQuestForKids/wwwroot/dist/_framework | head -20
-
-          # Strip web build dependencies so MAUI only packages the compiled Vite+Blazor output.
+          # Strip dev-only assets so the MAUI bundle only ships the compiled static site.
           cd BibleQuestForKids/wwwroot
           rm -rf node_modules src
           rm -f package.json package-lock.json vite.config.js tailwind.config.js postcss.config.js eslint.config.js \
-            jsconfig.json components.json README.md
+                jsconfig.json components.json README.md
 
-      - name: Normalize index.html for Blazor Hybrid
-        script: |
-          set -euo pipefail
-          INDEX_FILE="BibleQuestForKids/wwwroot/dist/index.html"
-          if [ ! -f "$INDEX_FILE" ]; then
-            echo "ERROR: index.html not found at $INDEX_FILE"
-            exit 1
-          fi
-
-          python3 <<'PY'
-            from pathlib import Path
-            import re
-
-            index_path = Path("BibleQuestForKids/wwwroot/dist/index.html")
-            html = index_path.read_text(encoding="utf-8")
-            original = html
-
-            # Remove any stale script tags that try to inject blazor.webview.js manually.
-            html = re.sub(
-                r"\s*<script[^>]+blazor\.webview\.js[^>]*></script>",
-                "",
-                html,
-                flags=re.IGNORECASE,
-            )
-
-            if html != original:
-                index_path.write_text(html, encoding="utf-8")
-          PY
-
-          echo "✅ Ensured dist/index.html lets the WebView inject blazor.webview.js"
-          head -n 20 "$INDEX_FILE"
-
-      - name: "Guard: Blazor files exist after npm build"
+      - name: Guard: dist contains index.html + JS bundle
         script: |
           set -euo pipefail
           cd BibleQuestForKids/wwwroot/dist
-
-          REQUIRED_FILES=("index.html" "_framework/blazor.boot.json" "_framework/dotnet.js")
-
-          for f in "${REQUIRED_FILES[@]}"; do
-            if [ ! -f "$f" ]; then
-              echo "ERROR: Missing required Blazor file: $f"
-              echo "Contents of dist/_framework (first 50 files):"
-              find _framework -type f | sort | head -50
-              exit 1
-            fi
-            SIZE=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f")
-            HASH=$(shasum -a 256 "$f" | awk '{print $1}')
-            echo "✅ $f — $SIZE bytes — SHA256: $HASH"
-          done
-
-          # Verify runtime references inside index.html
-          if ! grep -q "blazor.boot.json" index.html; then
-            echo "ERROR: index.html does not reference blazor.boot.json"
-            exit 1
-          fi
-          if ! grep -q "dotnet.js" index.html; then
-            echo "ERROR: index.html does not reference dotnet.js"
-            exit 1
-          fi
-
-          echo "✅ index.html contains references to blazor.boot.json and dotnet.js"
-          head -n 10 index.html
-
-      - name: "Guard: dist/ exists and references runtime"
-        script: |
-          set -euo pipefail
-          DIST="BibleQuestForKids/wwwroot/dist"
-          test -s "$DIST/index.html" || { echo "ERROR: dist/index.html missing"; exit 1; }
-
-          if ! grep -q "blazor.boot.json" "$DIST/index.html"; then
-            echo "ERROR: dist/index.html does not reference blazor.boot.json"
-            exit 1
-          fi
-          if ! grep -q "dotnet.js" "$DIST/index.html"; then
-            echo "ERROR: dist/index.html does not reference dotnet.js"
-            exit 1
-          fi
-
-          echo "✅ dist/index.html present and references the hybrid runtime files"
-          head -n 10 "$DIST/index.html" || true
+          [ -f index.html ] || { echo "ERROR: dist/index.html missing" >&2; exit 1; }
+          JS=$(ls assets/*.js 2>/dev/null | head -1 || true)
+          [ -n "$JS" ] || { echo "ERROR: no JS bundle in dist/assets" >&2; exit 1; }
+          echo "✅ dist/index.html and JS bundle present"
 
       - name: Configure Apple signing assets
         script: |
@@ -357,7 +265,7 @@ workflows:
           fi
           echo "OK: IPA build number validated."
 
-      - name: Verify IPA contains Blazor Hybrid assets
+      - name: Verify IPA contains dist assets
         script: |
           set -euo pipefail
           IPA_PATH=$(find BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish -maxdepth 1 -name '*.ipa' | head -1)
@@ -374,33 +282,22 @@ workflows:
             exit 1
           fi
 
-          echo "Listing dist/ inside IPA:"
+          echo "Listing dist/ inside IPA (first 20 files):"
           find "$TMP_DIR/Payload/$APP_DIR/wwwroot/dist" -type f | sort | head -20
 
-          REQUIRED_FILES=(
-            "$TMP_DIR/Payload/$APP_DIR/wwwroot/dist/index.html"
-            "$TMP_DIR/Payload/$APP_DIR/wwwroot/dist/_framework/blazor.boot.json"
-            "$TMP_DIR/Payload/$APP_DIR/wwwroot/dist/_framework/dotnet.js"
-          )
-
-          for f in "${REQUIRED_FILES[@]}"; do
-            if [ ! -f "$f" ]; then
-              echo "ERROR: Missing required Blazor Hybrid file in IPA: $f"
-              exit 1
-            fi
-          done
-
           INDEX_HTML="$TMP_DIR/Payload/$APP_DIR/wwwroot/dist/index.html"
-          if ! grep -q "blazor.boot.json" "$INDEX_HTML"; then
-            echo "ERROR: IPA index.html missing blazor.boot.json reference"
-            exit 1
-          fi
-          if ! grep -q "dotnet.js" "$INDEX_HTML"; then
-            echo "ERROR: IPA index.html missing dotnet.js reference"
+          if [ ! -f "$INDEX_HTML" ]; then
+            echo "ERROR: IPA missing dist/index.html" >&2
             exit 1
           fi
 
-          echo "✅ IPA verified for Blazor Hybrid runtime references"
+          JS=$(find "$TMP_DIR/Payload/$APP_DIR/wwwroot/dist/assets" -name '*.js' | head -1 || true)
+          if [ -z "$JS" ]; then
+            echo "ERROR: IPA missing JS bundle under dist/assets" >&2
+            exit 1
+          fi
+
+          echo "✅ IPA contains dist/index.html and at least one JS bundle"
           head -n 15 "$INDEX_HTML"
 
           OUTPUT_DIR="$PWD/output"


### PR DESCRIPTION
## Summary
- replace the BlazorWebView with a plain MAUI WebView that loads the bundled Vite dist assets
- show a branded splash handoff and warm the WebView before swapping to the main page to avoid white flicker
- streamline codemagic.yaml for the static WebView flow and verify dist output instead of Blazor runtime files

## Testing
- not run (Codemagic iOS workflow will rebuild and publish)

------
https://chatgpt.com/codex/tasks/task_e_68d980ce67708329bdf3bdaba793117f