### PR TITLE
Fix guard step name quoting in Codemagic workflow

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -95,7 +95,7 @@ workflows:
           rm -f package.json package-lock.json vite.config.js tailwind.config.js postcss.config.js eslint.config.js \
                 jsconfig.json components.json README.md
 
-      - name: Guard: dist contains index.html + JS bundle
+      - name: "Guard: dist contains index.html + JS bundle"
         script: |
           set -euo pipefail
           cd BibleQuestForKids/wwwroot/dist


### PR DESCRIPTION
## Summary
- quote the guard step name so the colon does not break YAML parsing

## Testing
- python3 -c "import sys, yaml; yaml.safe_load(open('codemagic.yaml'))"


------
https://chatgpt.com/codex/tasks/task_e_68d98314f3b08329bb0f54adeedf5690