### PR TITLE
Switch iOS delivery to GitHub Actions workflow

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -5,22 +5,31 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+env:
+  DOTNET_VERSION: 8.0.301
+  APP_IDENTIFIER: app.biblequest
+  APP_DISPLAY_VERSION: 1.1.0 # Reminder: update before App Store submission if marketing version changes
+
 jobs:
   build:
     runs-on: macos-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Setup .NET 8 SDK
+      - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Setup Node.js for web assets
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
 
       - name: Install MAUI workloads
-        # Install the MAUI and iOS workloads needed for publishing.
-        run: dotnet workload install maui ios
+        run: dotnet workload install maui-ios --skip-manifest-update
 
       - name: Configure NuGet sources
         run: |
@@ -33,32 +42,146 @@ jobs:
       - name: Restore NuGet packages
         run: dotnet restore BibleQuestForKids/BibleQuestForKids.sln --no-cache --disable-parallel --verbosity detailed
 
-      - name: Build iOS app
-        run: >-
-          dotnet build BibleQuestForKids/BibleQuestForKids.csproj
-          -c Release
-          -f net8.0-ios
-          -p:ArchiveOnBuild=true
-          -p:RuntimeIdentifier=ios-arm64
-          --verbosity detailed
+      - name: Build bundled web assets
+        working-directory: BibleQuestForKids/wwwroot
+        run: |
+          npm ci
+          npm run build
+        env:
+          CI: true
 
-      - name: Publish iOS IPA
+      - name: Strip development web assets
+        run: |
+          rm -rf BibleQuestForKids/wwwroot/node_modules BibleQuestForKids/wwwroot/src
+          rm -f BibleQuestForKids/wwwroot/package*.json
+
+      - name: Guard dist assets exist
+        run: |
+          DIST="BibleQuestForKids/wwwroot/dist"
+          if [ ! -s "$DIST/index.html" ]; then
+            echo "dist/index.html missing. Run npm build before publishing." >&2
+            exit 1
+          fi
+          echo "✅ Found dist/index.html"
+          head -n 10 "$DIST/index.html"
+
+      - name: Resolve build number (keeps TestFlight builds unique)
+        id: resolve-build
+        env:
+          APP_IDENTIFIER: ${{ env.APP_IDENTIFIER }}
+          APP_DISPLAY_VERSION: ${{ env.APP_DISPLAY_VERSION }}
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
+          APP_STORE_CONNECT_KEY_IDENTIFIER: ${{ secrets.APP_STORE_CONNECT_KEY_IDENTIFIER }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          BUILD_NUMBER=$(date +%s)
+          echo "Seeded APP_BUILD_NUMBER=$BUILD_NUMBER from epoch seconds"
+
+          if [ -n "${APP_STORE_CONNECT_PRIVATE_KEY:-}" ] && [ -n "${APP_STORE_CONNECT_KEY_IDENTIFIER:-}" ] && [ -n "${APP_STORE_CONNECT_ISSUER_ID:-}" ]; then
+            echo "Checking App Store Connect for safe build number"
+            FINAL_BUILD_NUMBER=$(APP_BUILD_NUMBER="$BUILD_NUMBER" \
+              APP_DISPLAY_VERSION="$APP_DISPLAY_VERSION" \
+              APP_IDENTIFIER="$APP_IDENTIFIER" \
+              APP_STORE_CONNECT_PRIVATE_KEY="$APP_STORE_CONNECT_PRIVATE_KEY" \
+              APP_STORE_CONNECT_KEY_IDENTIFIER="$APP_STORE_CONNECT_KEY_IDENTIFIER" \
+              APP_STORE_CONNECT_ISSUER_ID="$APP_STORE_CONNECT_ISSUER_ID" \
+              ruby ci/scripts/maybe_raise_build_number.rb)
+          else
+            echo "App Store Connect credentials missing. Using epoch build number."
+            FINAL_BUILD_NUMBER="$BUILD_NUMBER"
+          fi
+
+          if [ -z "$FINAL_BUILD_NUMBER" ]; then
+            echo "Failed to resolve build number" >&2
+            exit 1
+          fi
+
+          echo "APP_BUILD_NUMBER=$FINAL_BUILD_NUMBER" | tee -a "$GITHUB_ENV"
+
+      - name: Install signing assets
+        env:
+          APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          set -euo pipefail
+          if [ -z "${APPLE_CERTIFICATE_P12_BASE64:-}" ] || [ -z "${APPLE_CERTIFICATE_PASSWORD:-}" ]; then
+            echo "Missing APPLE_CERTIFICATE_P12_BASE64 or APPLE_CERTIFICATE_PASSWORD secrets" >&2
+            exit 1
+          fi
+
+          if [ -z "${APPLE_PROVISIONING_PROFILE_BASE64:-}" ]; then
+            echo "Missing APPLE_PROVISIONING_PROFILE_BASE64 secret" >&2
+            exit 1
+          fi
+
+          KEYCHAIN="signing.keychain-db"
+          security create-keychain -p "" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "" "$KEYCHAIN"
+
+          echo "$APPLE_CERTIFICATE_P12_BASE64" | base64 --decode > signing.p12
+          security import signing.p12 -k "$KEYCHAIN" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security delete-generic-password -l "signing" "$KEYCHAIN" 2>/dev/null || true
+
+          security list-keychains -s "$KEYCHAIN" $(security list-keychains | tr -d '"')
+          security set-key-partition-list -S apple-tool:,apple: -s -k "" "$KEYCHAIN"
+
+          PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "$PROFILE_DIR"
+          PROFILE_PATH="$PROFILE_DIR/${APP_IDENTIFIER}.mobileprovision"
+          echo "$APPLE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_PATH"
+
+          CODESIGN_IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" | head -1 | awk '{print $2}')
+          if [ -z "$CODESIGN_IDENTITY" ]; then
+            echo "No code signing identity found in imported certificate" >&2
+            exit 1
+          fi
+
+          {
+            echo "CODESIGN_KEY=$CODESIGN_IDENTITY"
+            echo "CODESIGN_PROVISION=$PROFILE_PATH"
+          } >> "$GITHUB_ENV"
+
+      - name: Publish .NET MAUI iOS app
         run: >-
           dotnet publish BibleQuestForKids/BibleQuestForKids.csproj
           -c Release
           -f net8.0-ios
           -p:RuntimeIdentifier=ios-arm64
-          -p:ArchiveOnBuild=true
           -p:BuildIpa=true
+          -p:ApplicationId=${{ env.APP_IDENTIFIER }}
+          -p:CFBundleIdentifier=${{ env.APP_IDENTIFIER }}
+          -p:ApplicationDisplayVersion=${{ env.APP_DISPLAY_VERSION }}
+          -p:ApplicationVersion=${{ env.APP_BUILD_NUMBER }}
+          -p:CodesignKey=${{ env.CODESIGN_KEY }}
+          -p:CodesignProvision=${{ env.CODESIGN_PROVISION }}
+          -p:CodesignTeamId=${{ secrets.TEAM_ID }}
           --verbosity detailed
+
+      - name: Verify IPA contains dist assets
+        run: |
+          IPA_PATH=$(find BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish -name '*.ipa' | head -1)
+          unzip -q "$IPA_PATH" -d tmp
+          APP_DIR=$(ls tmp/Payload)
+          if [ ! -f "tmp/Payload/$APP_DIR/wwwroot/dist/index.html" ]; then
+            echo "IPA missing dist/index.html" >&2
+            exit 1
+          fi
+          echo "✅ IPA contains dist/index.html"
 
       - name: Upload IPA to TestFlight
         uses: apple-actions/upload-testflight-build@v1
         with:
           app-path: BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish/*.ipa
-          issuer-id: ${{ secrets.APPLE_ISSUER_ID }}
-          api-key-id: ${{ secrets.APPLE_KEY_ID }}
-          api-private-key: ${{ secrets.APPLE_PRIVATE_KEY }}
-          apple-id: ${{ secrets.APPLE_ID }}
-          app-specific-password: ${{ secrets.APP_SPECIFIC_PASSWORD }}
-          team-id: ${{ secrets.TEAM_ID }}
+          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          api-key-id: ${{ secrets.APP_STORE_CONNECT_KEY_IDENTIFIER }}
+          api-private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
+          bundle-id: ${{ env.APP_IDENTIFIER }}
+
+      - name: Archive IPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: BibleQuestForKids-ipa
+          path: BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish/*.ipa

--- a/ci/scripts/clear_testflight_beta_review.rb
+++ b/ci/scripts/clear_testflight_beta_review.rb
@@ -48,7 +48,7 @@ def build_token(private_key_pem, key_id, issuer_id)
   "#{signing_input}.#{signature_b64}"
 end
 
-# Handle Codemagic environment variables that may be Base64 without PEM headers.
+# Handle CI environment variables that may be Base64 without PEM headers.
 def normalize_private_key(raw)
   expanded = raw.include?('-----BEGIN') ? raw : Base64.decode64(raw)
   expanded.gsub("\n", "\n")

--- a/ci/scripts/maybe_raise_build_number.rb
+++ b/ci/scripts/maybe_raise_build_number.rb
@@ -7,14 +7,14 @@ require 'json'
 require 'net/http'
 require 'uri'
 
-# Utility to fetch environment variables with helpful errors for Codemagic logs.
+# Utility to fetch environment variables with helpful errors for CI logs.
 def env!(name)
   value = ENV[name]
   raise "Missing required environment variable #{name}" if value.nil? || value.empty?
   value
 end
 
-# Handles the case where Codemagic stores the private key without PEM headers.
+# Handles the case where CI secrets may store the private key without PEM headers.
 def normalize_private_key(raw)
   return raw if raw.include?('-----BEGIN')
 

--- a/docs/APP_DESCRIPTION.md
+++ b/docs/APP_DESCRIPTION.md
@@ -45,4 +45,4 @@ Coins, XP, and stars tally automatically after minigames by reading performance 
 - Built-in seeding ensures first-time players always see content, even before church leaders upload custom verse banks.【F:BibleQuestForKids/wwwroot/src/pages/EmojiVerse.jsx†L1-L80】【F:BibleQuestForKids/wwwroot/src/pages/WiseWordle.jsx†L1-L120】
 
 ## Ready for TestFlight and App Store
-The codemagic.yaml pipeline will package this .NET MAUI build for iOS TestFlight distribution first, then App Store release once localization, screenshots, and App Store Connect metadata match the experiences detailed above. Keep the descriptions handy when filling out TestFlight beta notes versus App Store listing copy.
+The `.github/workflows/ios-build.yml` GitHub Actions pipeline now packages this .NET MAUI build for iOS TestFlight distribution first, then App Store release once localization, screenshots, and App Store Connect metadata match the experiences detailed above. Keep the descriptions handy when filling out TestFlight beta notes versus App Store listing copy so marketing language stays consistent across TestFlight and App Store submissions.


### PR DESCRIPTION
## Summary
- replace the macOS GitHub Actions workflow with a full signing, build, and TestFlight upload pipeline for the MAUI app
- carry existing build number logic and TestFlight safeguards into the workflow and align helper scripts with generic CI usage
- document the new workflow path in the TestFlight/App Store readiness notes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9ad249a18832999979443a43be2e7