### PR TITLE
Fix TestFlight beta review JWT padding

### DIFF
--- a/ci/scripts/clear_testflight_beta_review.rb
+++ b/ci/scripts/clear_testflight_beta_review.rb
@@ -16,15 +16,11 @@ def env!(name)
 end
 
 # Pad signature components for App Store Connect JWT signing.
+# Converts the big integer to a 32-byte, big-endian binary string.
 def pad_component(component)
-  bytes = component.to_s(2)
-  if bytes.bytesize < 32
-    ("\x00" * (32 - bytes.bytesize)) + bytes
-  elsif bytes.bytesize > 32
-    bytes[-32, 32]
-  else
-    bytes
-  end
+  hex = component.to_s(16)
+  hex = "0#{hex}" if hex.length.odd?
+  [hex].pack('H*').rjust(32, "\x00")
 end
 
 # Build a JWT to interact with App Store Connect.


### PR DESCRIPTION
## Summary
- convert the TestFlight beta review cleanup script to pad JWT signature components as 32-byte big-endian values so ES256 signing works reliably

## Testing
- ruby -c ci/scripts/clear_testflight_beta_review.rb

------
https://chatgpt.com/codex/tasks/task_e_68d9f339c6548329ba99cc7702d6dd87