### PR TITLE
Fix NuGet source command in iOS workflow

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -38,7 +38,8 @@ jobs:
         run: dotnet nuget remove source nuget-org || true
 
       - name: Add nuget.org source (idempotent)
-        run: dotnet nuget add source --name nuget-org --source https://api.nuget.org/v3/index.json
+        # dotnet nuget add source expects the feed URL as a positional argument.
+        run: dotnet nuget add source https://api.nuget.org/v3/index.json --name nuget-org
 
       - name: Verify configured NuGet sources
         run: dotnet nuget list source


### PR DESCRIPTION
## Summary
- correct the dotnet nuget add syntax so the nuget.org feed is added successfully
- note expected positional argument usage to avoid future regressions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9f98221ac83298faf5b8b8943384a