### PR TITLE
Fix MAUI iOS workflow paths and validate restore output

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -50,16 +50,22 @@ jobs:
         run: |
           echo "🔍 Repo root:"
           ls -la
-          echo "🔍 BibleQuest folder:"
-          ls -la BibleQuest
           echo "🔍 BibleQuestForKids folder:"
-          ls -la BibleQuest/BibleQuestForKids
+          ls -la BibleQuestForKids
 
       - name: Restore NuGet packages
-        run: dotnet restore BibleQuest/BibleQuestForKids/BibleQuestForKids.csproj --no-cache --disable-parallel --verbosity detailed
+        run: dotnet restore BibleQuestForKids/BibleQuestForKids.csproj --no-cache --disable-parallel --verbosity detailed
+
+      - name: Verify restore generated assets
+        run: |
+          if [ ! -f BibleQuestForKids/obj/project.assets.json ]; then
+            echo "❌ Restore did not generate project.assets.json"
+            exit 1
+          fi
+          echo "✅ Found project.assets.json"
 
       - name: Build bundled web assets
-        working-directory: BibleQuest/BibleQuestForKids/wwwroot
+        working-directory: BibleQuestForKids/wwwroot
         run: |
           npm ci
           npm run build
@@ -68,12 +74,12 @@ jobs:
 
       - name: Strip development web assets
         run: |
-          rm -rf BibleQuest/BibleQuestForKids/wwwroot/node_modules BibleQuest/BibleQuestForKids/wwwroot/src
-          rm -f BibleQuest/BibleQuestForKids/wwwroot/package*.json
+          rm -rf BibleQuestForKids/wwwroot/node_modules BibleQuestForKids/wwwroot/src
+          rm -f BibleQuestForKids/wwwroot/package*.json
 
       - name: Guard dist assets exist
         run: |
-          DIST="BibleQuest/BibleQuestForKids/wwwroot/dist"
+          DIST="BibleQuestForKids/wwwroot/dist"
           if [ ! -s "$DIST/index.html" ]; then
             echo "dist/index.html missing. Run npm build before publishing." >&2
             exit 1
@@ -162,7 +168,7 @@ jobs:
 
       - name: Publish .NET MAUI iOS app
         run: >-
-          dotnet publish BibleQuest/BibleQuestForKids/BibleQuestForKids.csproj
+          dotnet publish BibleQuestForKids/BibleQuestForKids.csproj
           -c Release
           -f net8.0-ios
           -p:RuntimeIdentifier=ios-arm64
@@ -178,7 +184,7 @@ jobs:
 
       - name: Verify IPA contains dist assets
         run: |
-          IPA_PATH=$(find BibleQuest/BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish -name '*.ipa' | head -1)
+          IPA_PATH=$(find BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish -name '*.ipa' | head -1)
           unzip -q "$IPA_PATH" -d tmp
           APP_DIR=$(ls tmp/Payload)
           if [ ! -f "tmp/Payload/$APP_DIR/wwwroot/dist/index.html" ]; then
@@ -190,7 +196,7 @@ jobs:
       - name: Upload IPA to TestFlight
         uses: apple-actions/upload-testflight-build@v1
         with:
-          app-path: BibleQuest/BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish/*.ipa
+          app-path: BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish/*.ipa
           issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           api-key-id: ${{ secrets.APP_STORE_CONNECT_KEY_IDENTIFIER }}
           api-private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
@@ -200,4 +206,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: BibleQuestForKids-ipa
-          path: BibleQuest/BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish/*.ipa
+          path: BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish/*.ipa


### PR DESCRIPTION
## Summary
- correct the .NET project and artifact paths in the iOS build workflow so they match the repository layout
- add an explicit check that dotnet restore produced obj/project.assets.json before continuing the build

## Testing
- not run (workflow update)


------
https://chatgpt.com/codex/tasks/task_e_68d9fd4f68c08329ab5f8aee19b33094