### PR TITLE
Fix iOS workflow YAML and provisioning setup

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,160 +1,176 @@
 name: iOS Build & Deploy (Bible Quest for Kids)
 
 on:
-push:
-branches: [“main”]
-workflow_dispatch:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
+# Global defaults shared across steps. Keep APP_DISPLAY_VERSION in sync
+# with App Store metadata before a production submission; TestFlight
+# builds can safely reuse the same value between beta iterations.
 env:
-DOTNET_VERSION: 8.0.301
-APP_IDENTIFIER: app.biblequest
-APP_DISPLAY_VERSION: 1.1.0
+  DOTNET_VERSION: '8.0.301'
+  APP_IDENTIFIER: app.biblequest
+  APP_DISPLAY_VERSION: '1.1.0'
 
 jobs:
-build:
-runs-on: macos-latest
+  build:
+    name: Build and upload TestFlight binary
+    runs-on: macos-14
 
-```
-steps:
-  - name: Checkout repository
-    uses: actions/checkout@v4
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-  - name: Debug repo contents
-    run: |
-      echo "=== Repo Root ==="
-      ls -R
-      echo "=== Looking for .csproj files ==="
-      find . -type f -name "*.csproj" || true
-      echo "=== Looking for .sln files ==="
-      find . -type f -name "*.sln" || true
+      - name: Discover key project files
+        run: |
+          echo '== .csproj files =='
+          find . -maxdepth 5 -name '*.csproj' -print
+          echo '== .sln files =='
+          find . -maxdepth 5 -name '*.sln' -print
 
-  - name: Setup .NET SDK
-    uses: actions/setup-dotnet@v4
-    with:
-      dotnet-version: ${{ env.DOTNET_VERSION }}
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
 
-  - name: Setup Node.js for web assets
-    uses: actions/setup-node@v4
-    with:
-      node-version: 18
+      - name: Setup Node.js for web assets
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
-  - name: Install MAUI workloads
-    run: |
-      dotnet workload install maui --skip-manifest-update
-      dotnet workload list
+      - name: Install required MAUI workloads
+        run: |
+          dotnet workload install maui-ios --skip-manifest-update
+          dotnet workload list
 
-  - name: Configure NuGet sources
-    run: |
-      if ! dotnet nuget list source | grep -q "https://api.nuget.org/v3/index.json"; then
-        dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget-org
-      else
-        echo "✅ nuget.org feed already present"
-      fi
-      dotnet nuget list source
+      - name: Ensure NuGet.org feed is available
+        run: |
+          if ! dotnet nuget list source | grep -q 'https://api.nuget.org/v3/index.json'; then
+            dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget-org
+          fi
+          dotnet nuget list source
 
-  - name: Restore workloads from project
-    run: dotnet workload restore BibleQuestForKids/BibleQuestForKids.csproj
+      - name: Restore workloads declared by the project
+        run: dotnet workload restore BibleQuestForKids/BibleQuestForKids.csproj
 
-  - name: Restore NuGet packages
-    run: dotnet restore BibleQuestForKids/BibleQuestForKids.csproj --no-cache --disable-parallel --verbosity detailed
+      - name: Restore NuGet packages
+        run: dotnet restore BibleQuestForKids/BibleQuestForKids.csproj --no-cache --disable-parallel
 
-  - name: Build bundled web assets
-    working-directory: BibleQuestForKids/wwwroot
-    run: |
-      npm ci
-      npm run build
-    env:
-      CI: true
+      - name: Build bundled web assets
+        working-directory: BibleQuestForKids/wwwroot
+        env:
+          CI: 'true'
+        run: |
+          npm ci
+          npm run build
 
-  - name: Strip development web assets
-    run: |
-      rm -rf BibleQuestForKids/wwwroot/node_modules BibleQuestForKids/wwwroot/src
-      rm -f BibleQuestForKids/wwwroot/package*.json
+      - name: Strip development web assets before publishing
+        run: |
+          rm -rf BibleQuestForKids/wwwroot/node_modules BibleQuestForKids/wwwroot/src
+          rm -f BibleQuestForKids/wwwroot/package*.json
 
-  - name: Guard dist assets exist
-    run: |
-      DIST="BibleQuestForKids/wwwroot/dist"
-      if [ ! -s "$DIST/index.html" ]; then
-        echo "dist/index.html missing. Run npm build before publishing." >&2
-        exit 1
-      fi
-      echo "✅ Found dist/index.html"
-      head -n 10 "$DIST/index.html"
+      - name: Guard dist assets exist
+        run: |
+          DIST='BibleQuestForKids/wwwroot/dist'
+          if [ ! -s "$DIST/index.html" ]; then
+            echo 'dist/index.html missing. Run npm build before publishing.' >&2
+            exit 1
+          fi
+          echo '✅ Found dist/index.html'
+          head -n 10 "$DIST/index.html"
 
-  - name: Resolve build number
-    id: resolve-build
-    env:
-      APP_IDENTIFIER: ${{ env.APP_IDENTIFIER }}
-      APP_DISPLAY_VERSION: ${{ env.APP_DISPLAY_VERSION }}
-      APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
-      APP_STORE_CONNECT_KEY_IDENTIFIER: ${{ secrets.APP_STORE_CONNECT_KEY_IDENTIFIER }}
-      APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-    run: |
-      set -euo pipefail
-      BUILD_NUMBER=$(date +%s)
-      echo "Seeded APP_BUILD_NUMBER=$BUILD_NUMBER from epoch seconds"
-      echo "APP_BUILD_NUMBER=$BUILD_NUMBER" | tee -a "$GITHUB_ENV"
+      - name: Resolve build number
+        id: resolve-build
+        env:
+          APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
+          APP_STORE_CONNECT_KEY_IDENTIFIER: ${{ secrets.APP_STORE_CONNECT_KEY_IDENTIFIER }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          BUILD_NUMBER=$(date +%s)
+          echo "Seeded APP_BUILD_NUMBER=$BUILD_NUMBER from epoch seconds"
+          echo "APP_BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_ENV"
 
-  - name: Install signing assets
-    env:
-      APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
-      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-      APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
-    run: |
-      set -euo pipefail
-      KEYCHAIN="signing.keychain-db"
-      security create-keychain -p "" "$KEYCHAIN"
-      security set-keychain-settings -lut 21600 "$KEYCHAIN"
-      security unlock-keychain -p "" "$KEYCHAIN"
-      echo "$APPLE_CERTIFICATE_P12_BASE64" | base64 --decode > signing.p12
-      security import signing.p12 -k "$KEYCHAIN" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
-      PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
-      mkdir -p "$PROFILE_DIR"
-      PROFILE_PATH="$PROFILE_DIR/${APP_IDENTIFIER}.mobileprovision"
-      echo "$APPLE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_PATH"
-      CODESIGN_IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" | head -1 | awk '{print $2}')
-      echo "CODESIGN_KEY=$CODESIGN_IDENTITY" >> "$GITHUB_ENV"
-      echo "CODESIGN_PROVISION=$PROFILE_PATH" >> "$GITHUB_ENV"
+      - name: Install signing assets
+        env:
+          APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+          TEAM_ID: ${{ secrets.TEAM_ID }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN='signing.keychain-db'
+          security create-keychain -p '' "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p '' "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
 
-  - name: Publish .NET MAUI iOS app
-    run: >-
-      dotnet publish BibleQuestForKids/BibleQuestForKids.csproj
-      -c Release
-      -f net8.0-ios
-      -p:RuntimeIdentifier=ios-arm64
-      -p:BuildIpa=true
-      -p:ApplicationId=${{ env.APP_IDENTIFIER }}
-      -p:CFBundleIdentifier=${{ env.APP_IDENTIFIER }}
-      -p:ApplicationDisplayVersion=${{ env.APP_DISPLAY_VERSION }}
-      -p:ApplicationVersion=${{ env.APP_BUILD_NUMBER }}
-      -p:CodesignKey=${{ env.CODESIGN_KEY }}
-      -p:CodesignProvision=${{ env.CODESIGN_PROVISION }}
-      -p:CodesignTeamId=${{ secrets.TEAM_ID }}
-      --verbosity detailed
+          echo "$APPLE_CERTIFICATE_P12_BASE64" | base64 --decode > signing.p12
+          security import signing.p12 -k "$KEYCHAIN" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -s -k '' "$KEYCHAIN"
 
-  - name: Verify IPA contains dist assets
-    run: |
-      IPA_PATH=$(find BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish -name '*.ipa' | head -1)
-      unzip -q "$IPA_PATH" -d tmp
-      APP_DIR=$(ls tmp/Payload)
-      if [ ! -f "tmp/Payload/$APP_DIR/wwwroot/dist/index.html" ]; then
-        echo "IPA missing dist/index.html" >&2
-        exit 1
-      fi
-      echo "✅ IPA contains dist/index.html"
+          PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "$PROFILE_DIR"
+          PROFILE_PATH="$PROFILE_DIR/${APP_IDENTIFIER}.mobileprovision"
+          echo "$APPLE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_PATH"
 
-  - name: Upload IPA to TestFlight
-    uses: apple-actions/upload-testflight-build@v1
-    with:
-      app-path: BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish/*.ipa
-      issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-      api-key-id: ${{ secrets.APP_STORE_CONNECT_KEY_IDENTIFIER }}
-      api-private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
-      bundle-id: ${{ env.APP_IDENTIFIER }}
+          CODESIGN_IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" | head -1 | awk '{print $2}')
+          if [ -z "$CODESIGN_IDENTITY" ]; then
+            echo 'No signing identity located in keychain.' >&2
+            exit 1
+          fi
 
-  - name: Archive IPA artifact
-    uses: actions/upload-artifact@v4
-    with:
-      name: BibleQuestForKids-ipa
-      path: BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish/*.ipa
-```
+          {
+            echo "CODESIGN_KEY=$CODESIGN_IDENTITY"
+            echo "CODESIGN_PROVISION=$PROFILE_PATH"
+            echo "TEAM_ID=$TEAM_ID"
+          } >> "$GITHUB_ENV"
+
+      - name: Publish .NET MAUI iOS app
+        run: >-
+          dotnet publish BibleQuestForKids/BibleQuestForKids.csproj
+          -c Release
+          -f net8.0-ios
+          -p:RuntimeIdentifier=ios-arm64
+          -p:BuildIpa=true
+          -p:ApplicationId=${{ env.APP_IDENTIFIER }}
+          -p:CFBundleIdentifier=${{ env.APP_IDENTIFIER }}
+          -p:ApplicationDisplayVersion=${{ env.APP_DISPLAY_VERSION }}
+          -p:ApplicationVersion=${{ env.APP_BUILD_NUMBER }}
+          -p:CodesignKey=${{ env.CODESIGN_KEY }}
+          -p:CodesignProvision=${{ env.CODESIGN_PROVISION }}
+          -p:CodesignTeamId=${{ env.TEAM_ID }}
+          --verbosity minimal
+
+      - name: Verify IPA contains dist assets
+        run: |
+          IPA_PATH=$(find BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish -name '*.ipa' | head -1)
+          if [ -z "$IPA_PATH" ]; then
+            echo 'No IPA found after publish step.' >&2
+            exit 1
+          fi
+          unzip -q "$IPA_PATH" -d tmp
+          APP_DIR=$(ls tmp/Payload)
+          if [ ! -f "tmp/Payload/$APP_DIR/wwwroot/dist/index.html" ]; then
+            echo 'IPA missing dist/index.html' >&2
+            exit 1
+          fi
+          echo '✅ IPA contains dist/index.html'
+
+      - name: Upload IPA to TestFlight (does not submit to App Store review)
+        uses: apple-actions/upload-testflight-build@v1
+        with:
+          app-path: BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish/*.ipa
+          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          api-key-id: ${{ secrets.APP_STORE_CONNECT_KEY_IDENTIFIER }}
+          api-private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
+          bundle-id: ${{ env.APP_IDENTIFIER }}
+
+      - name: Archive IPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: BibleQuestForKids-ipa
+          path: BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish/*.ipa
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- replace the malformed ios-build workflow with valid YAML and comments reminding how TestFlight differs from App Store submissions
- refresh setup steps to use Node 20, targeted MAUI workloads, and explicit signing asset handling for Codemagic secrets
- ensure IPA verification, TestFlight upload, and artifact archiving run with guarded failure messages

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68da6e03b0e08329a7d05bae344d516b