### PR TITLE
Allow TestFlight cleanup to skip when API key lacks permissions

### DIFF
--- a/ci/scripts/clear_testflight_beta_review.rb
+++ b/ci/scripts/clear_testflight_beta_review.rb
@@ -66,6 +66,14 @@ apps_req['Authorization'] = "Bearer #{token}"
 apps_res = Net::HTTP.start(apps_uri.host, apps_uri.port, use_ssl: true) { |http| http.request(apps_req) }
 unless apps_res.is_a?(Net::HTTPSuccess)
   warn "Failed to query App Store Connect apps: #{apps_res.code} #{apps_res.body}"
+
+  # Allow builds to continue even when the API key cannot list apps (common on TestFlight-only keys).
+  if apps_res.is_a?(Net::HTTPUnauthorized) || apps_res.is_a?(Net::HTTPForbidden)
+    warn 'App Store Connect API key is missing the App Manager (or higher) role. '
+    warn 'Skipping TestFlight beta review cleanup so the build can still upload.'
+    exit 0
+  end
+
   exit 1
 end
 


### PR DESCRIPTION
## Summary
- skip TestFlight beta review cleanup when App Store Connect API key returns 401/403 so uploads continue

## Testing
- not run (uses existing CI)


------
https://chatgpt.com/codex/tasks/task_e_68da707281308329b29f45e0520e686c