### PR TITLE
Prevent duplicate provisioning profile copy

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -190,7 +190,11 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$(dirname "$LEGACY_PROVISION_PATH")"
-          cp "${{ env.CODESIGN_PROVISION }}" "$LEGACY_PROVISION_PATH"
+          if [ "${{ env.CODESIGN_PROVISION }}" = "$LEGACY_PROVISION_PATH" ]; then
+            echo "CODESIGN_PROVISION already matches legacy path; skipping duplicate copy."
+          else
+            cp "${{ env.CODESIGN_PROVISION }}" "$LEGACY_PROVISION_PATH"
+          fi
           echo "LEGACY_PROVISION_PATH=$LEGACY_PROVISION_PATH" >> "$GITHUB_ENV"
 
       - name: Guard exported provisioning profile path


### PR DESCRIPTION
## Summary
- skip copying the provisioning profile when the source and legacy paths match so the workflow no longer fails on macOS runners

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68daf93e5a248329a3062d9871175889