### PR TITLE
Stabilize MAUI iOS build pipeline and React asset packaging

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -2,17 +2,19 @@ name: iOS Build & Deploy (Bible Quest for Kids)
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - "main"
   workflow_dispatch:
 
 env:
   DOTNET_VERSION: 8.0.300
+  NODE_VERSION: 18
   APP_IDENTIFIER: app.biblequest
   APP_DISPLAY_VERSION: 1.1.0
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       - name: Checkout repository
@@ -26,49 +28,73 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+          cache-dependency-path: BibleQuestForKids/wwwroot/package-lock.json
 
       - name: Configure NuGet sources
+        shell: bash
         run: |
+          set -euo pipefail
           echo "🧩 Configuring NuGet feeds"
-          dotnet nuget list source || true
-          dotnet nuget remove source nuget-org || true
-          dotnet nuget remove source maui-feed || true
+          existing_sources=$(dotnet nuget list source | awk 'NR>2 {print $2}')
+          if echo "$existing_sources" | grep -q "nuget-org"; then
+            dotnet nuget remove source nuget-org
+          fi
+          if echo "$existing_sources" | grep -q "dotnet8"; then
+            dotnet nuget remove source dotnet8
+          fi
           dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget-org
           dotnet nuget add source https://aka.ms/dotnet8/nuget/index.json -n dotnet8
           dotnet nuget list source
 
       - name: Install MAUI workloads
+        shell: bash
         run: |
-          echo "📦 Installing MAUI iOS workloads from official feed"
-          dotnet workload install maui-ios --source https://aka.ms/dotnet8/nuget/index.json --skip-sign-check
+          set -euo pipefail
+          echo "📦 Installing MAUI iOS workloads"
+          dotnet workload install maui-ios \
+            --source https://aka.ms/dotnet8/nuget/index.json \
+            --skip-sign-check
           dotnet workload list
 
       - name: Restore NuGet packages
-        run: dotnet restore BibleQuestForKids/BibleQuestForKids.csproj --no-cache --disable-parallel --verbosity minimal
+        shell: bash
+        run: |
+          dotnet restore BibleQuestForKids/BibleQuestForKids.csproj \
+            --no-cache \
+            --disable-parallel \
+            --verbosity minimal
 
       - name: Build bundled web assets
+        shell: bash
         working-directory: BibleQuestForKids/wwwroot
+        env:
+          CI: true
         run: |
           npm ci
           npm run build
-        env:
-          CI: true
 
       - name: Guard dist assets exist
+        shell: bash
         run: |
+          set -euo pipefail
           DIST="BibleQuestForKids/wwwroot/dist"
-          if [ ! -s "$DIST/index.html" ]; then
-            echo "❌ dist/index.html missing" >&2
+          test -s "$DIST/index.html"
+          test -s "$DIST/manifest.json"
+          if ! ls "$DIST"/*.js >/dev/null 2>&1; then
+            echo "❌ No JavaScript bundles produced" >&2
             exit 1
           fi
           echo "✅ dist assets verified"
 
       - name: Resolve build number
         id: resolve-build
-        run: echo "APP_BUILD_NUMBER=$(date +%s)" >> $GITHUB_ENV
+        shell: bash
+        run: echo "APP_BUILD_NUMBER=$(date +%s)" >> "$GITHUB_ENV"
 
       - name: Install signing assets
+        shell: bash
         env:
           APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -79,32 +105,55 @@ jobs:
           security create-keychain -p "" "$KEYCHAIN"
           security set-keychain-settings -lut 21600 "$KEYCHAIN"
           security unlock-keychain -p "" "$KEYCHAIN"
+          security list-keychain -d user -s "$KEYCHAIN" $(security list-keychain -d user | tr -d '"')
 
           echo "$APPLE_CERTIFICATE_P12_BASE64" | base64 --decode > signing.p12
           security import signing.p12 -k "$KEYCHAIN" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -k "" "$KEYCHAIN"
 
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
           PROFILE_PATH="$HOME/Library/MobileDevice/Provisioning Profiles/${{ env.APP_IDENTIFIER }}.mobileprovision"
           echo "$APPLE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_PATH"
 
-          CODESIGN_IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" | head -1 | awk '{print $2}')
-          echo "CODESIGN_KEY=$CODESIGN_IDENTITY" >> $GITHUB_ENV
-          echo "CODESIGN_PROVISION=$PROFILE_PATH" >> $GITHUB_ENV
+          CODESIGN_IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" | head -n 1 | awk '{print $2}')
+          if [ -z "$CODESIGN_IDENTITY" ]; then
+            echo "❌ Unable to locate codesign identity" >&2
+            exit 1
+          fi
+          echo "CODESIGN_KEY=$CODESIGN_IDENTITY" >> "$GITHUB_ENV"
+          echo "CODESIGN_PROVISION=$PROFILE_PATH" >> "$GITHUB_ENV"
 
       - name: Publish .NET MAUI iOS app
-        run: >
-          dotnet publish BibleQuestForKids/BibleQuestForKids.csproj
-          -c Release
-          -f net8.0-ios
-          -p:RuntimeIdentifier=ios-arm64
-          -p:BuildIpa=true
-          -p:ApplicationId=${{ env.APP_IDENTIFIER }}
-          -p:CFBundleIdentifier=${{ env.APP_IDENTIFIER }}
-          -p:ApplicationDisplayVersion=${{ env.APP_DISPLAY_VERSION }}
-          -p:ApplicationVersion=${{ env.APP_BUILD_NUMBER }}
-          -p:CodesignKey=${{ env.CODESIGN_KEY }}
-          -p:CodesignProvision=${{ env.CODESIGN_PROVISION }}
-          -p:CodesignTeamId=${{ secrets.TEAM_ID }}
+        shell: bash
+        run: |
+          dotnet publish BibleQuestForKids/BibleQuestForKids.csproj \
+            -c Release \
+            -f net8.0-ios \
+            -p:RuntimeIdentifier=ios-arm64 \
+            -p:BuildIpa=true \
+            -p:ApplicationId=${{ env.APP_IDENTIFIER }} \
+            -p:CFBundleIdentifier=${{ env.APP_IDENTIFIER }} \
+            -p:ApplicationDisplayVersion=${{ env.APP_DISPLAY_VERSION }} \
+            -p:ApplicationVersion=${{ env.APP_BUILD_NUMBER }} \
+            -p:CodesignKey=${{ env.CODESIGN_KEY }} \
+            -p:CodesignProvision=${{ env.CODESIGN_PROVISION }} \
+            -p:CodesignTeamId=${{ secrets.TEAM_ID }} \
+            --no-restore
+
+      - name: Verify IPA contains dist assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          IPA_PATH=$(find BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish -name '*.ipa' | head -n 1)
+          if [ -z "$IPA_PATH" ]; then
+            echo "❌ IPA not found" >&2
+            exit 1
+          fi
+          unzip -q "$IPA_PATH" -d tmp-ipa
+          APP_DIR=$(ls tmp-ipa/Payload)
+          test -s "tmp-ipa/Payload/$APP_DIR/wwwroot/dist/index.html"
+          test -s "tmp-ipa/Payload/$APP_DIR/wwwroot/dist/manifest.json"
+          echo "✅ IPA contains compiled web assets"
 
       - name: Upload IPA to TestFlight
         uses: apple-actions/upload-testflight-build@v1

--- a/BibleQuestForKids/App.xaml.cs
+++ b/BibleQuestForKids/App.xaml.cs
@@ -1,6 +1,4 @@
 using Microsoft.Maui.Controls;
-using Microsoft.AspNetCore.Components.WebView.Maui;
-using BibleQuestForKids.Pages;  // ✅ add this so Main.razor is recognized
 
 namespace BibleQuestForKids
 {
@@ -9,22 +7,7 @@ namespace BibleQuestForKids
         public App()
         {
             InitializeComponent();
-
-            MainPage = new ContentPage
-            {
-                Content = new BlazorWebView
-                {
-                    HostPage = "wwwroot/index.html",
-                    RootComponents =
-                    {
-                        new RootComponent
-                        {
-                            Selector = "#app",
-                            ComponentType = typeof(Main)  // ✅ now maps to Main.razor
-                        }
-                    }
-                }
-            };
+            MainPage = new MainPage();
         }
     }
 }

--- a/BibleQuestForKids/BibleQuestForKids.csproj
+++ b/BibleQuestForKids/BibleQuestForKids.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0-android;net8.0-ios</TargetFrameworks>
@@ -8,29 +8,31 @@
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EnableDefaultStaticWebAssets>true</EnableDefaultStaticWebAssets>
+    <BlazorWebViewEnableDefaultStyles>false</BlazorWebViewEnableDefaultStyles>
+  </PropertyGroup>
 
-    <!-- App metadata -->
+  <PropertyGroup>
     <ApplicationTitle>Bible Quest for Kids</ApplicationTitle>
     <ApplicationId>app.biblequest</ApplicationId>
     <ApplicationVersion>1.1.0</ApplicationVersion>
     <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
+  </PropertyGroup>
 
-    <!-- Hybrid build flags -->
-    <EnableDefaultStaticWebAssets>true</EnableDefaultStaticWebAssets>
-    <BlazorWebViewEnableDefaultStyles>false</BlazorWebViewEnableDefaultStyles>
-
-    <!-- iOS-specific -->
-    <RuntimeIdentifier>ios-arm64</RuntimeIdentifier>
+  <PropertyGroup Condition="'$(TargetFramework)'=='net8.0-ios'">
+    <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
     <MtouchEnableBitcode>false</MtouchEnableBitcode>
   </PropertyGroup>
 
-  <!-- Fonts -->
+  <PropertyGroup Condition="'$(TargetFramework)'=='net8.0-android'">
+    <SupportedOSPlatformVersion>24.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <MauiFont Include="Resources/Fonts/OpenSans-Regular.ttf" Alias="OpenSansRegular" />
     <MauiFont Include="Resources/Fonts/OpenSans-Semibold.ttf" Alias="OpenSansSemibold" />
   </ItemGroup>
 
-  <!-- NuGet Packages -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.60" />
     <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.60" />
@@ -38,24 +40,34 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="8.0.60" />
   </ItemGroup>
 
-  <!-- Assets -->
   <ItemGroup>
-    <MauiImage Include="Resources\Images\*" />
-    <MauiSplashScreen Include="Resources\Splash\*" />
-    <MauiAsset Include="Resources\Raw\**" />
-    <MauiAsset Include="wwwroot\**" LogicalName="wwwroot\%(RecursiveDir)%(Filename)%(Extension)" />
+    <None Remove="wwwroot\node_modules\**" />
+    <Content Remove="wwwroot\node_modules\**" />
+    <None Remove="wwwroot\src\**" />
+    <Content Remove="wwwroot\src\**" />
   </ItemGroup>
 
-  <!-- Copy web build output into the app -->
-  <Target Name="CopyDistToOutput" AfterTargets="Build">
+  <ItemGroup>
+    <MauiImage Include="Resources/Images/*" />
+    <MauiSplashScreen Include="Resources/Splash/*" />
+    <MauiAsset Include="Resources/Raw/**" />
+    <MauiAsset Include="wwwroot/**" LogicalName="wwwroot/%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <Target Name="CopyDistAssets" AfterTargets="Build;Publish" Condition="Exists('wwwroot/dist')">
     <ItemGroup>
       <DistFiles Include="wwwroot/dist/**" />
     </ItemGroup>
     <Copy
       SourceFiles="@(DistFiles)"
-      DestinationFolder="$(OutDir)\wwwroot\dist\%(RecursiveDir)"
+      DestinationFiles="@(DistFiles->'$(OutDir)wwwroot/dist/%(RecursiveDir)%(Filename)%(Extension)')"
       SkipUnchangedFiles="true"
-      Condition="Exists('wwwroot/dist')" />
+      Condition="'$(OutDir)' != ''" />
+    <Copy
+      SourceFiles="@(DistFiles)"
+      DestinationFiles="@(DistFiles->'$(PublishDir)wwwroot/dist/%(RecursiveDir)%(Filename)%(Extension)')"
+      SkipUnchangedFiles="true"
+      Condition="'$(PublishDir)' != ''" />
   </Target>
 
 </Project>

--- a/BibleQuestForKids/MainPage.xaml
+++ b/BibleQuestForKids/MainPage.xaml
@@ -1,9 +1,18 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:blazor="clr-namespace:Microsoft.AspNetCore.Components.WebView.Maui;assembly=Microsoft.AspNetCore.Components.WebView.Maui"
+             xmlns:pages="clr-namespace:BibleQuestForKids.Pages"
              x:Class="BibleQuestForKids.MainPage"
              NavigationPage.HasNavigationBar="False">
     <Grid>
-        <WebView x:Name="AppWebView" />
+        <blazor:BlazorWebView HostPage="wwwroot/index.html"
+                               BackgroundColor="Transparent"
+                               HorizontalOptions="Fill"
+                               VerticalOptions="Fill">
+            <blazor:BlazorWebView.RootComponents>
+                <blazor:RootComponent Selector="#app" ComponentType="{x:Type pages:Main}" />
+            </blazor:BlazorWebView.RootComponents>
+        </blazor:BlazorWebView>
     </Grid>
 </ContentPage>

--- a/BibleQuestForKids/MainPage.xaml.cs
+++ b/BibleQuestForKids/MainPage.xaml.cs
@@ -1,5 +1,4 @@
 using Microsoft.Maui.Controls;
-using Microsoft.Maui.Graphics;
 
 namespace BibleQuestForKids;
 
@@ -8,10 +7,5 @@ public partial class MainPage : ContentPage
     public MainPage()
     {
         InitializeComponent();
-        // Transparent background avoids a white flash during WebView initialization.
-        AppWebView.BackgroundColor = Colors.Transparent;
-
-        // Load the bundled Vite build directly from the application package.
-        AppWebView.Source = "appbundle:/wwwroot/dist/index.html";
     }
 }

--- a/BibleQuestForKids/MauiProgram.cs
+++ b/BibleQuestForKids/MauiProgram.cs
@@ -1,7 +1,9 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Maui;
 using Microsoft.Maui.Controls.Hosting;
 using Microsoft.Maui.Hosting;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.AspNetCore.Components.WebView.Maui; // ✅ Required for AddMauiBlazorWebView
+using Microsoft.AspNetCore.Components.WebView.Maui;
 
 namespace BibleQuestForKids
 {
@@ -19,12 +21,11 @@ namespace BibleQuestForKids
                     fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
                 });
 
-            // ✅ Register Blazor WebView
             builder.Services.AddMauiBlazorWebView();
 
 #if DEBUG
-            // ✅ Enable developer tools in Debug mode
             builder.Services.AddBlazorWebViewDeveloperTools();
+            builder.Logging.AddDebug();
 #endif
 
             return builder.Build();

--- a/BibleQuestForKids/Pages/Main.razor
+++ b/BibleQuestForKids/Pages/Main.razor
@@ -1,4 +1,6 @@
 @page "/"
+@using Microsoft.JSInterop
+@inject IJSRuntime JS
 
 <h1>Bible Quest for Kids</h1>
 
@@ -11,21 +13,20 @@
 </div>
 
 @code {
-    [Inject] IJSRuntime JS { get; set; } = default!;
-
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
+        if (!firstRender)
         {
-            try
-            {
-                // Call the JS bootstrapper in wwwroot/index.html
-                await JS.InvokeVoidAsync("BibleQuest.loadReactApp");
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"React bootstrap failed: {ex.Message}");
-            }
+            return;
+        }
+
+        try
+        {
+            await JS.InvokeVoidAsync("BibleQuest.loadReactApp");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"React bootstrap failed: {ex.Message}");
         }
     }
 }

--- a/BibleQuestForKids/_Imports.razor
+++ b/BibleQuestForKids/_Imports.razor
@@ -1,0 +1,6 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using BibleQuestForKids
+@using BibleQuestForKids.Pages

--- a/BibleQuestForKids/wwwroot/index.html
+++ b/BibleQuestForKids/wwwroot/index.html
@@ -33,7 +33,9 @@
 
         namespace.ensureBlazorRuntime = async () => {
           if (!runtimeScript) {
-            console.info("BibleQuest: blazor.webview.js not present; skipping MAUI runtime probe.");
+            console.info(
+              "BibleQuest: blazor.webview.js not present; skipping MAUI runtime probe."
+            );
             return null;
           }
 
@@ -45,7 +47,7 @@
               const bootResponse = await fetch(bootUrl);
               if (!bootResponse.ok) {
                 throw new Error(
-                  `Blazor boot manifest fetch failed: ${bootResponse.status} ${bootResponse.statusText}`,
+                  `Blazor boot manifest fetch failed: ${bootResponse.status} ${bootResponse.statusText}`
                 );
               }
 
@@ -66,7 +68,7 @@
             return;
           }
 
-          const manifestUrl = new URL("./manifest.json", window.location.href);
+          const manifestUrl = new URL("./dist/manifest.json", window.location.href);
 
           try {
             if (runtimeScript) {
@@ -79,13 +81,14 @@
 
             const manifest = await manifestResponse.json();
             const manifestValues = Object.values(manifest ?? {});
-            const entry = manifest["src/main.jsx"] ?? manifestValues.find((item) => item && item.isEntry);
+            const entry =
+              manifest["src/main.jsx"] ?? manifestValues.find((item) => item && item.isEntry);
             if (!entry) {
               throw new Error("Unable to locate the React entry in dist/manifest.json.");
             }
 
             const ensureStylesheet = (relativePath) => {
-              const href = new URL(`./${relativePath}`, manifestUrl).href;
+              const href = new URL(relativePath, manifestUrl).href;
               if (document.querySelector(`link[data-react-bundle='${href}']`)) {
                 return;
               }
@@ -97,7 +100,7 @@
               document.head.appendChild(link);
             };
 
-            (entry.css ?? []).forEach((cssFile) => ensureStylesheet(cssFile));
+            (entry.css ?? []).forEach((cssFile) => ensureStylesheet(`./${cssFile}`));
 
             const bundleUrl = new URL(`./${entry.file}`, manifestUrl);
             await import(bundleUrl.href);
@@ -109,7 +112,6 @@
       })();
     </script>
 
-    <!-- ✅ Trigger React load -->
     <script>
       window.BibleQuest?.loadReactApp();
     </script>

--- a/BibleQuestForKids/wwwroot/package.json
+++ b/BibleQuestForKids/wwwroot/package.json
@@ -1,8 +1,12 @@
 {
-  "name": "base44-app",
+  "name": "biblequest-www",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=9.0.0"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/BibleQuestForKids/wwwroot/vite.config.js
+++ b/BibleQuestForKids/wwwroot/vite.config.js
@@ -1,27 +1,37 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import { fileURLToPath } from 'url'
 
-// https://vite.dev/config/
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
 export default defineConfig({
-  // Build relative paths so the bundled assets work when loaded from
-  // the on-device file system (e.g., TestFlight installs).
   base: './',
   plugins: [react()],
   server: {
-    allowedHosts: true
+    allowedHosts: true,
   },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': path.resolve(__dirname, 'src'),
     },
-    extensions: ['.mjs', '.js', '.jsx', '.ts', '.tsx', '.json']
+    extensions: ['.mjs', '.js', '.jsx', '.ts', '.tsx', '.json'],
   },
   optimizeDeps: {
     esbuildOptions: {
       loader: {
         '.js': 'jsx',
       },
+    },
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    manifest: true,
+    sourcemap: false,
+    rollupOptions: {
+      input: path.resolve(__dirname, 'src/main.jsx'),
     },
   },
 })

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,156 +1,141 @@
-name: iOS Build & Deploy (Bible Quest for Kids)
-
-on:
-  push:
-    branches: [ "main" ]
-  workflow_dispatch:
-
-env:
-  DOTNET_VERSION: 8.0.301
-  APP_IDENTIFIER: app.biblequest
-  APP_DISPLAY_VERSION: 1.1.0
-
-jobs:
-  build:
-    runs-on: macos-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 18
-
+workflows:
+  ios-maui:
+    name: "iOS Build & Deploy (Bible Quest for Kids)"
+    max_build_duration: 120
+    instance_type: mac_mini_m2
+    environment:
+      xcode: 16.2
+      node: 18
+      vars:
+        DOTNET_VERSION: 8.0.300
+        APP_IDENTIFIER: app.biblequest
+        APP_DISPLAY_VERSION: 1.1.0
+      groups:
+        - app_store_connect
+        - ios_signing
+    triggering:
+      events:
+        - push
+      branch_patterns:
+        - pattern: main
+          include: true
+          source: true
+    cache:
+      cache_paths:
+        - ~/.nuget/packages
+        - BibleQuestForKids/wwwroot/node_modules
+    scripts:
+      - name: Install .NET SDK
+        script: |
+          set -euo pipefail
+          export DOTNET_ROOT="$HOME/.dotnet"
+          mkdir -p "$DOTNET_ROOT"
+          curl -fsSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --version "$DOTNET_VERSION" --install-dir "$DOTNET_ROOT"
+          export PATH="$DOTNET_ROOT:$DOTNET_ROOT/tools:$PATH"
+          dotnet --info
       - name: Install MAUI workloads
-        run: dotnet workload install maui-ios --skip-manifest-update
-
-      - name: Configure NuGet sources
-        run: |
-          set -e
-          if dotnet nuget list source | grep -q "nuget-org"; then
-            dotnet nuget remove source nuget-org
-          fi
-          if dotnet nuget list source | grep -q "maui-feed"; then
-            dotnet nuget remove source maui-feed
-          fi
-          dotnet nuget add source https://api.nuget.org/v3/index.json -n nuget-org
-          dotnet nuget add source https://pkgs.dev.azure.com/dnceng/public/_packaging/maui/nuget/v3/index.json -n maui-feed
-          dotnet nuget list source
-
-      # 👇 New step to prevent stale caches
-      - name: Clean before restore
-        run: |
-          dotnet clean BibleQuestForKids/BibleQuestForKids.csproj -c Release
-          rm -rf ~/.nuget/packages
-
+        script: |
+          set -euo pipefail
+          dotnet workload install maui-ios \
+            --source https://aka.ms/dotnet8/nuget/index.json \
+            --skip-sign-check
       - name: Restore NuGet packages
-        run: dotnet restore BibleQuestForKids/BibleQuestForKids.csproj --no-cache --disable-parallel --verbosity minimal
-
+        script: |
+          set -euo pipefail
+          dotnet restore BibleQuestForKids/BibleQuestForKids.csproj \
+            --no-cache \
+            --disable-parallel \
+            --verbosity minimal
       - name: Build bundled web assets
-        working-directory: BibleQuestForKids/wwwroot
-        run: |
+        script: |
+          set -euo pipefail
+          pushd BibleQuestForKids/wwwroot
           npm ci
           npm run build
-        env:
-          CI: true
-
-      - name: Strip dev-only assets
-        run: |
+          popd
+      - name: Strip dev-only node assets
+        script: |
+          set -euo pipefail
           rm -rf BibleQuestForKids/wwwroot/node_modules BibleQuestForKids/wwwroot/src
-          rm -f BibleQuestForKids/wwwroot/package*.json
-
+          rm -f BibleQuestForKids/wwwroot/package*.json BibleQuestForKids/wwwroot/vite.config.js BibleQuestForKids/wwwroot/tsconfig*.json
+          rm -f BibleQuestForKids/wwwroot/postcss.config.js BibleQuestForKids/wwwroot/tailwind.config.js BibleQuestForKids/wwwroot/eslint.config.js BibleQuestForKids/wwwroot/jsconfig.json BibleQuestForKids/wwwroot/components.json
       - name: Guard dist assets exist
-        run: |
+        script: |
+          set -euo pipefail
           DIST="BibleQuestForKids/wwwroot/dist"
-          if [ ! -s "$DIST/index.html" ]; then
-            echo "❌ dist/index.html missing" >&2
-            exit 1
-          fi
-          if [ ! -s "$DIST/manifest.json" ]; then
-            echo "❌ dist/manifest.json missing" >&2
-            exit 1
-          fi
+          test -s "$DIST/index.html"
+          test -s "$DIST/manifest.json"
           if ! ls "$DIST"/*.js >/dev/null 2>&1; then
-            echo "❌ no JS bundles in dist/" >&2
+            echo "❌ No JavaScript bundles produced" >&2
             exit 1
           fi
           if ! ls "$DIST"/*.css >/dev/null 2>&1; then
-            echo "❌ no CSS bundles in dist/" >&2
+            echo "❌ No CSS bundles produced" >&2
             exit 1
           fi
-          echo "✅ dist assets verified"
-
       - name: Resolve build number
-        id: resolve-build
-        run: echo "APP_BUILD_NUMBER=$(date +%s)" >> $GITHUB_ENV
-
+        script: |
+          set -euo pipefail
+          echo "APP_BUILD_NUMBER=$(date +%s)" >> "$CM_ENV"
       - name: Install signing assets
-        env:
-          APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
-        run: |
+        script: |
           set -euo pipefail
           KEYCHAIN="signing.keychain-db"
           security create-keychain -p "" "$KEYCHAIN"
           security set-keychain-settings -lut 21600 "$KEYCHAIN"
           security unlock-keychain -p "" "$KEYCHAIN"
+          security list-keychain -d user -s "$KEYCHAIN" $(security list-keychain -d user | tr -d '"')
 
           echo "$APPLE_CERTIFICATE_P12_BASE64" | base64 --decode > signing.p12
           security import signing.p12 -k "$KEYCHAIN" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -k "" "$KEYCHAIN"
 
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
-          PROFILE_PATH="$HOME/Library/MobileDevice/Provisioning Profiles/${{ env.APP_IDENTIFIER }}.mobileprovision"
+          PROFILE_PATH="$HOME/Library/MobileDevice/Provisioning Profiles/${APP_IDENTIFIER}.mobileprovision"
           echo "$APPLE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_PATH"
 
-          CODESIGN_IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" | head -1 | awk '{print $2}')
-          echo "CODESIGN_KEY=$CODESIGN_IDENTITY" >> $GITHUB_ENV
-          echo "CODESIGN_PROVISION=$PROFILE_PATH" >> $GITHUB_ENV
-
-      - name: Publish .NET MAUI iOS app
-        run: >
-          dotnet publish BibleQuestForKids/BibleQuestForKids.csproj
-          -c Release
-          -f net8.0-ios
-          -p:RuntimeIdentifier=ios-arm64
-          -p:BuildIpa=true
-          -p:ApplicationId=${{ env.APP_IDENTIFIER }}
-          -p:CFBundleIdentifier=${{ env.APP_IDENTIFIER }}
-          -p:ApplicationDisplayVersion=${{ env.APP_DISPLAY_VERSION }}
-          -p:ApplicationVersion=${{ env.APP_BUILD_NUMBER }}
-          -p:CodesignKey=${{ env.CODESIGN_KEY }}
-          -p:CodesignProvision=${{ env.CODESIGN_PROVISION }}
-          -p:CodesignTeamId=${{ secrets.TEAM_ID }}
-
-      - name: Verify IPA contains dist assets
-        run: |
-          IPA_PATH=$(find BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish -name '*.ipa' | head -1)
-          unzip -q "$IPA_PATH" -d tmp
-          APP_DIR=$(ls tmp/Payload)
-          if [ ! -f "tmp/Payload/$APP_DIR/wwwroot/dist/index.html" ]; then
-            echo "❌ IPA missing dist/index.html" >&2
+          CODESIGN_IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" | head -n 1 | awk '{print $2}')
+          if [ -z "$CODESIGN_IDENTITY" ]; then
+            echo "❌ Unable to locate codesign identity" >&2
             exit 1
           fi
-          echo "✅ IPA contains dist/index.html"
-
-      - name: Upload IPA to TestFlight
-        uses: apple-actions/upload-testflight-build@v1
-        with:
-          app-path: BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish/*.ipa
-          issuer-id: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-          api-key-id: ${{ secrets.APP_STORE_CONNECT_KEY_IDENTIFIER }}
-          api-private-key: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}
-          bundle-id: ${{ env.APP_IDENTIFIER }}
-
-      - name: Archive IPA artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: BibleQuestForKids-ipa
-          path: BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish/*.ipa
+          echo "CODESIGN_KEY=$CODESIGN_IDENTITY" >> "$CM_ENV"
+          echo "CODESIGN_PROVISION=$PROFILE_PATH" >> "$CM_ENV"
+      - name: Publish .NET MAUI iOS app
+        script: |
+          set -euo pipefail
+          export PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$PATH"
+          dotnet publish BibleQuestForKids/BibleQuestForKids.csproj \
+            -c Release \
+            -f net8.0-ios \
+            -p:RuntimeIdentifier=ios-arm64 \
+            -p:BuildIpa=true \
+            -p:ApplicationId=$APP_IDENTIFIER \
+            -p:CFBundleIdentifier=$APP_IDENTIFIER \
+            -p:ApplicationDisplayVersion=$APP_DISPLAY_VERSION \
+            -p:ApplicationVersion=$APP_BUILD_NUMBER \
+            -p:CodesignKey=$CODESIGN_KEY \
+            -p:CodesignProvision=$CODESIGN_PROVISION \
+            -p:CodesignTeamId=$TEAM_ID \
+            --no-restore
+      - name: Verify IPA contains dist assets
+        script: |
+          set -euo pipefail
+          IPA_PATH=$(find BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish -name '*.ipa' | head -n 1)
+          if [ -z "$IPA_PATH" ]; then
+            echo "❌ IPA not found" >&2
+            exit 1
+          fi
+          unzip -q "$IPA_PATH" -d tmp-ipa
+          APP_DIR=$(ls tmp-ipa/Payload)
+          test -s "tmp-ipa/Payload/$APP_DIR/wwwroot/dist/index.html"
+          test -s "tmp-ipa/Payload/$APP_DIR/wwwroot/dist/manifest.json"
+    artifacts:
+      - BibleQuestForKids/bin/Release/net8.0-ios/ios-arm64/publish/*.ipa
+    publishing:
+      app_store_connect:
+        auth: api_key
+        key_id: $APP_STORE_CONNECT_KEY_IDENTIFIER
+        issuer_id: $APP_STORE_CONNECT_ISSUER_ID
+        private_key: $APP_STORE_CONNECT_PRIVATE_KEY
+        submit_to_testflight: true


### PR DESCRIPTION
## Summary
- fix the MAUI project to use the correct SDK, platform targets, and asset handling for the React bundle
- rebuild the MainPage/Blazor host wiring so the Razor root component and React bootstrap run correctly
- harden the GitHub Actions and Codemagic workflows with deterministic workload install, signing setup, and TestFlight upload steps
- ensure the Vite build emits a manifest and document the Node/npm requirements for CI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1706734108329996a6eecf1d19f76