### PR TITLE
Fix Codemagic App Store Connect auth configuration

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -29,6 +29,8 @@ workflows:
 
     publishing:
       app_store_connect:
-        # 👇 This must match the App Store Connect integration you’ve created in Codemagic
-        auth: integration
+        auth: api_key
+        key_id: $APP_STORE_CONNECT_KEY_IDENTIFIER
+        issuer_id: $APP_STORE_CONNECT_ISSUER_ID
+        private_key: $APP_STORE_CONNECT_PRIVATE_KEY
         submit_to_testflight: true


### PR DESCRIPTION
## Summary
- switch the Codemagic App Store Connect publishing configuration to use API key authentication backed by existing secrets
- ensure the TestFlight submission flag is retained for release builds

## Testing
- not run (configuration change only)

------
https://chatgpt.com/codex/tasks/task_e_68e2b57769988329b371d89542398d16